### PR TITLE
Add first Github Action CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
         ref: master
     # Ensure the site succeeds Hugo builds. If it fails for some reason, the pipeline will halt.
     - name: Build site with Hugo
-      uses: lowply/build-hugo@v0.74.1
+      run: hugo -D

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   build:
-  # In this phase, the code is pulled from master and the site rendered in Hugo. The built site is stored as an artifact for other stages.
     runs-on: ubuntu-latest
     steps:
     # Check out master branch from the repo.
@@ -21,7 +20,17 @@ jobs:
       with:
         submodules: true  # Fetch Hugo themes
         fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
-        ref: master
-    # Ensure the site succeeds Hugo builds. If it fails for some reason, the pipeline will halt.
-    - name: Build Hugo
-      uses: lowply/build-hugo@v0.79.0
+
+    # Sets up the latest version of Hugo
+    - name: Setup Hugo
+      uses: peaceiris/actions-hugo@v2
+      with:
+          hugo-version: 'latest'
+
+    # Clean and don't fail
+    - name: Clean public directory
+      run: rm -rf public
+
+    # Builds the site using the latest version of Hugo
+    - name: Build
+      run: hugo -D

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+on:
+  workflow_dispatch:
+    branches:
+    - master
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+  # In this phase, the code is pulled from master and the site rendered in Hugo. The built site is stored as an artifact for other stages.
+    runs-on: ubuntu-latest
+    steps:
+    # Check out master branch from the repo.
+    - name: Checkout master branch
+      uses: actions/checkout@v2
+      with:
+        submodules: true  # Fetch Hugo themes
+        fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+        ref: master
+    # Ensure the site succeeds Hugo builds. If it fails for some reason, the pipeline will halt.
+    - name: Build site with Hugo
+      uses: lowply/build-hugo@v0.74.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
     - name: Checkout master branch
       uses: actions/checkout@v2
       with:
-        submodules: recursive  # Fetch Hugo themes
+        submodules: true  # Fetch Hugo themes
         fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
         ref: master
     # Ensure the site succeeds Hugo builds. If it fails for some reason, the pipeline will halt.
-    - name: Build site with Hugo
-      uses: lowply/build-hugo@v0.74.1
+    - name: Build Hugo
+      uses: lowply/build-hugo@v0.79.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
     - name: Checkout master branch
       uses: actions/checkout@v2
       with:
-        submodules: true  # Fetch Hugo themes
+        submodules: recursive  # Fetch Hugo themes
         fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
         ref: master
     # Ensure the site succeeds Hugo builds. If it fails for some reason, the pipeline will halt.
     - name: Build site with Hugo
-      run: hugo -D
+      uses: lowply/build-hugo@v0.74.1


### PR DESCRIPTION
This change implements a CI workflow to validate the Hugo site build using Github Actions.

Following this guide:
https://neonmirrors.net/post/2020-05/cicd-for-hugo-on-aws/